### PR TITLE
Use cucumber-junit-platform-engine and junit-platform-suite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <serenity.version>3.1.5</serenity.version>
+        <serenity.version>3.1.16-SNAPSHOT</serenity.version>
+        <cucumber.version>7.0.0</cucumber.version>
         <encoding>UTF-8</encoding>
         <tags></tags>
         <webdriver.base.url></webdriver.base.url>
@@ -54,15 +55,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.8.1</version>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <version>1.8.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>5.8.1</version>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
+            <version>${cucumber.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/starter/CucumberTestSuite.java
+++ b/src/test/java/starter/CucumberTestSuite.java
@@ -1,12 +1,13 @@
 package starter;
 
-import io.cucumber.junit.CucumberOptions;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
-import org.junit.runner.RunWith;
+import io.cucumber.junit.platform.engine.Constants;
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(CucumberWithSerenity.class)
-@CucumberOptions(
-        plugin = {"pretty"},
-        features = "src/test/resources/features"
-)
+@Suite
+@SelectClasspathResource("features")
+@ConfigurationParameter(key = Constants.GLUE_PROPERTY_NAME, value = "starter")
+@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "io.cucumber.core.plugin.SerenityReporter")
+@ConfigurationParameter(key = Constants.PLUGIN_PUBLISH_QUIET_PROPERTY_NAME, value = "true")
 public class CucumberTestSuite {}


### PR DESCRIPTION
see https://github.com/cucumber/cucumber-jvm/tree/v7.0.0/junit-platform-engine

- substitute cucumber-junit-platform-engine and junit-platform-suite to junit4 or junit-vintage-engine
- configure suite to execute cucumber with features from class path
- configure cucumber glue package and serenity reporter

requires https://github.com/serenity-bdd/serenity-core/pull/2648