### PR TITLE
#106 Fix: could not compile in Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
                 "org.junit.jupiter:junit-jupiter-api:${junitVersion}",
                 "org.assertj:assertj-core:${assertJVersion}",
                 "ch.qos.logback:logback-classic:${logbackVersion}"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:${junitVersion}"
 }
 
 test {


### PR DESCRIPTION
#### Summary of this PR
1. Gradle build failed 
a. missing curly bracket in build gradle 
b. serenity gradle plugin version was not found.
2. Tests were not picked up by JUnit 5 runner due to the wrong artifact was used in Gradle. 

#### Intended effect
It will build with Gradle again. Tests will run again with Gradle.

#### How should this be manually tested?
Just build the project first: 
`gradle clean build -x test`
Then run the tests:
`gradle clean test`

#### Side effects
N/A
#### Documentation
N/A
#### Relevant tickets
https://github.com/serenity-bdd/serenity-cucumber-starter/issues/106
https://github.com/serenity-bdd/serenity-cucumber-starter/issues/105
#### Screenshots (if appropriate)
N/A