### PR TITLE
settings in build.gradle for project compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
-plugins id "net.serenity-bdd.serenity-gradle-plugin" version "3.5.1"
+plugins {
+    id "net.serenity-bdd.serenity-gradle-plugin" version "3.5.0"
     id 'java'
     id 'eclipse'
     id 'idea'
@@ -35,7 +36,6 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform()
     testLogging.showStandardStreams = true
     systemProperties System.getProperties()
 }


### PR DESCRIPTION
- the version 3.5.1 of the gradle plugin does not exist, with the previous one the project works OK

- a '{' is missing which is a syntax error

- cucumber project does not run correctly with junit executor