### PR TITLE
Bump setup-java action in living-documentation workflow

### DIFF
--- a/.github/workflows/living-documentation.yml
+++ b/.github/workflows/living-documentation.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: '17'
         distribution: 'adopt'


### PR DESCRIPTION
Bumps the `setup-java` action version to match the updates to the other workflows, so that it understands the new `distribution` and `cache` options.