### PR TITLE
Fix typo at junit-platform-suite version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <serenity.version>4.0.15</serenity.version>
         <junit-vintage-engine.version>5.1.0</junit-vintage-engine.version>
-        <junit-platform-suite.version>1.1.0</junit-platform-suite.version>
+        <junit-platform-suite.version>1.10.0</junit-platform-suite.version>
         <cucumber-junit-platform-engine.version>7.14.0</cucumber-junit-platform-engine.version>
         <encoding>UTF-8</encoding>
         <tags></tags>


### PR DESCRIPTION
Hello. This PR is a simple typo fix at `junit-platform-suite` version in the `pom.xml` file. The version should be `1.10.0` instead of `1.1.0`.